### PR TITLE
Fix the function name called in the tutorial

### DIFF
--- a/Tutorials/Tutorial 1 - Decision Tree Classifier/pyZAN Tutorial.py
+++ b/Tutorials/Tutorial 1 - Decision Tree Classifier/pyZAN Tutorial.py
@@ -43,6 +43,7 @@ from sklearn import metrics
 # First connect to our analyzer
 zan = pyZAN.Server(server='localhost', metadb='ZA_Predictive820')
 
+#Test
 # Get projects, archives and variables
 projects = zan.read_MetaData_Projects()
 archives = zan.read_MetaData_Archives()

--- a/Tutorials/Tutorial 1 - Decision Tree Classifier/pyZAN Tutorial.py
+++ b/Tutorials/Tutorial 1 - Decision Tree Classifier/pyZAN Tutorial.py
@@ -51,7 +51,7 @@ variables = zan.read_MetaData_Variables()
 # We will focus on R1_WeldingCurrent, R1_WeldingResistance, R1_WeldingVoltage and R1_Status
 # Let's get our healthy data
 
-healthy = zan.read_Online_Archiv(project_reference = "PREDICTIVE_MAINTENANCE_DEMO_820",\
+healthy = zan.read_Online_Archive(project_reference = "PREDICTIVE_MAINTENANCE_DEMO_820",\
                                  archive_reference = "PA",\
                                  variable_references = [\
                                  "RobotSimForPA/Global/R1_WeldingResistance",\
@@ -219,7 +219,7 @@ healthy_sliced = healthy_sliced.R1_WeldingCurrent
 healthy_ml = healthy_sliced.unstack()
 
 # our healthy data is ready... we now need an unhealthy data set
-unhealthy = zan.read_Online_Archiv(project_reference = "PREDICTIVE_MAINTENANCE_DEMO_820",\
+unhealthy = zan.read_Online_Archive(project_reference = "PREDICTIVE_MAINTENANCE_DEMO_820",\
                                  archive_reference = "PA",\
                                  variable_references = [\
                                  "RobotSimForPA/Global/R1_WeldingResistance",\
@@ -311,7 +311,7 @@ tree.plot_tree(clf)
 
 # Get base data and transform it
 
-test_data = zan.read_Online_Archiv(project_reference = "PREDICTIVE_MAINTENANCE_DEMO_820",\
+test_data = zan.read_Online_Archive(project_reference = "PREDICTIVE_MAINTENANCE_DEMO_820",\
                                  archive_reference = "PA",\
                                  variable_references = [\
                                  "RobotSimForPA/Global/R1_WeldingResistance",\
@@ -336,7 +336,7 @@ test_data = test_data[['R1_WeldingCurrent','R1_Status']]
 # In my case, as I used R1 Error 3, I will load R1_Error3_Toggle as an label
 # if it is 1 our data is unhealthy
 
-label_data = zan.read_Online_Archiv(project_reference = "PREDICTIVE_MAINTENANCE_DEMO_820",\
+label_data = zan.read_Online_Archive(project_reference = "PREDICTIVE_MAINTENANCE_DEMO_820",\
                                  archive_reference = "AS",\
                                  variable_references = ["RobotSimForPA/ErrorAdditionR1/R1_Error3_Toggle"],\
                                  time_from = datetime.datetime(2019,12,3,9,40,0),\

--- a/Tutorials/Tutorial 2 - Time Series Prediction With LSTMs/pyZAN Tutorial - timeseries prediction.py
+++ b/Tutorials/Tutorial 2 - Time Series Prediction With LSTMs/pyZAN Tutorial - timeseries prediction.py
@@ -60,7 +60,7 @@ variables = zan.read_MetaData_Variables()
                                                         
 # We will focus on R1_WeldingCurrent and use 1 hour of data for training
 
-train_data = zan.read_Online_Archiv(project_reference = "PREDICTIVE_MAINTENANCE_DEMO_820",\
+train_data = zan.read_Online_Archive(project_reference = "PREDICTIVE_MAINTENANCE_DEMO_820",\
                                  archive_reference = "PA",\
                                  variable_references = ["RobotSimForPA/Global/R1_WeldingCurrent"],\
                                  time_from = datetime.datetime(2019,12,3,7,20,0),\
@@ -234,7 +234,7 @@ model2.save('LSTM Model 2_4Layers.h5')
 # Now we wil compare the two models by prediction the same timeframe
 # and comparing the results
 # let's load a new dataset from zenon
-eval_data = zan.read_Online_Archiv(project_reference = "PREDICTIVE_MAINTENANCE_DEMO_820",\
+eval_data = zan.read_Online_Archive(project_reference = "PREDICTIVE_MAINTENANCE_DEMO_820",\
                                  archive_reference = "PA",\
                                  variable_references = ["RobotSimForPA/Global/R1_WeldingCurrent"],\
                                  time_from = datetime.datetime(2019,12,3,7,20,0),\


### PR DESCRIPTION
When I checked it because an error occurred in the tutorial, the function name was different.
The function name in pyZAN.py was read_Online_Archive, so I adapted the tutorial to this.